### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "lodash.clone": "^4.5.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.get": "^4.4.2",
-    "node-uuid": "^1.4.7",
     "redux": "^3.5.2",
     "reflect-metadata": "^0.1.3",
     "source-map-support": "^0.4.0",
-    "typelogger": "^1.0.24"
+    "typelogger": "^1.0.24",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "@types/bluebird": "^3.0.35",

--- a/src/actions/ActionFactory.ts
+++ b/src/actions/ActionFactory.ts
@@ -10,7 +10,7 @@ import {Reducer, State} from '../reducers'
 
 
 const
-	uuid = require('node-uuid'),
+	uuid = require('uuid'),
 	log = getLogger(__filename)
 
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.